### PR TITLE
Add artifact collection command, compiler-wrapper helpers, and CI workflow improvements

### DIFF
--- a/.github/workflows/add-new-project.yml
+++ b/.github/workflows/add-new-project.yml
@@ -51,7 +51,7 @@ jobs:
           workspaces: ci_core_rs
 
       - name: Build CI Core
-        run: cargo build --release --manifest-path ci_core_rs/Cargo.toml
+        run: cargo build --release --locked --manifest-path ci_core_rs/Cargo.toml
 
       - name: Add to Configuration
         run: |

--- a/.github/workflows/add-new-project.yml
+++ b/.github/workflows/add-new-project.yml
@@ -38,24 +38,17 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v6
-      
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@nightly
-        with:
-          toolchain: nightly
-          components: rustfmt, clippy
 
-      - name: Cache Rust
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: ci_core_rs
-
-      - name: Build CI Core
-        run: cargo build --release --locked --manifest-path ci_core_rs/Cargo.toml
+      - name: Download CI Core
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          gh release download ci-core-latest -p "kokuban_ci_core" --clobber
+          chmod +x kokuban_ci_core
 
       - name: Add to Configuration
         run: |
-          ./ci_core_rs/target/release/kokuban_ci_core add \
+          ./kokuban_ci_core add \
             --key "${{ inputs.project_key }}" \
             --repo "${{ inputs.repo_path }}" \
             --defconfig "${{ inputs.defconfig }}" \

--- a/.github/workflows/build_ci_core.yml
+++ b/.github/workflows/build_ci_core.yml
@@ -22,7 +22,7 @@ jobs:
           workspaces: ci_core_rs
 
       - name: Build CI Core
-        run: cargo build --release --manifest-path ci_core_rs/Cargo.toml
+        run: cargo build --release --locked --manifest-path ci_core_rs/Cargo.toml
 
       - name: Release CI Core
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/build_kernel.yml
+++ b/.github/workflows/build_kernel.yml
@@ -70,44 +70,44 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    env:
+      ARTIFACT_DIR: build_artifacts
     steps:
       - uses: actions/checkout@v6
 
-      - name: Normalize Inputs
-        id: inputs
+      - name: Resolve Build Parameters
         run: |
-          PROJECT=""
-          BRANCH=""
-          VARIANT="default"
-          RELEASE="true"
-          CUSTOM_LOCALVERSION=""
-          CUSTOM_BUILD_TIME=""
-
-          if [ "${{ github.event_name }}" == "repository_dispatch" ]; then
-            PROJECT="${{ github.event.client_payload.project }}"
-            BRANCH="${{ github.event.client_payload.branch }}"
-          elif [ "${{ github.event_name }}" == "workflow_call" ]; then
-            PROJECT="${{ inputs.project }}"
-            BRANCH="${{ inputs.branch }}"
-            VARIANT="${{ inputs.ksu_variant }}"
-            RELEASE="${{ inputs.do_release }}"
-            CUSTOM_LOCALVERSION="${{ inputs.custom_localversion }}"
-            CUSTOM_BUILD_TIME="${{ inputs.custom_build_time }}"
+          if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
+            project="${{ github.event.client_payload.project }}"
+            branch="${{ github.event.client_payload.branch }}"
+            variant="default"
+            release="true"
+            custom_localversion=""
+            custom_build_time=""
           else
-            PROJECT="${{ inputs.project }}"
-            BRANCH="${{ inputs.branch }}"
-            VARIANT="${{ inputs.ksu_variant }}"
-            RELEASE="${{ inputs.do_release }}"
-            CUSTOM_LOCALVERSION="${{ inputs.custom_localversion }}"
-            CUSTOM_BUILD_TIME="${{ inputs.custom_build_time }}"
+            project="${{ inputs.project }}"
+            branch="${{ inputs.branch }}"
+            variant="${{ inputs.ksu_variant }}"
+            release="${{ inputs.do_release }}"
+            custom_localversion="${{ inputs.custom_localversion }}"
+            custom_build_time="${{ inputs.custom_build_time }}"
           fi
 
-          echo "PROJECT=${PROJECT}" >> $GITHUB_ENV
-          echo "BRANCH_TARGET=${BRANCH}" >> $GITHUB_ENV
-          echo "VARIANT_INPUT=${VARIANT}" >> $GITHUB_ENV
-          echo "DO_RELEASE=${RELEASE}" >> $GITHUB_ENV
-          echo "CUSTOM_LOCALVERSION=${CUSTOM_LOCALVERSION}" >> $GITHUB_ENV
-          echo "CUSTOM_BUILD_TIME=${CUSTOM_BUILD_TIME}" >> $GITHUB_ENV
+          if [ "$variant" = "default" ] || [ -z "$variant" ]; then
+            resolved_variant="$branch"
+          else
+            resolved_variant="$variant"
+          fi
+
+          {
+            echo "PROJECT=$project"
+            echo "BRANCH_TARGET=$branch"
+            echo "VARIANT_INPUT=$variant"
+            echo "VARIANT=$resolved_variant"
+            echo "DO_RELEASE=$release"
+            echo "CUSTOM_LOCALVERSION=$custom_localversion"
+            echo "CUSTOM_BUILD_TIME=$custom_build_time"
+          } >> "$GITHUB_ENV"
 
       - name: Download CI Core
         env:
@@ -118,14 +118,6 @@ jobs:
 
       - name: Parse Configuration
         run: ./kokuban_ci_core parse --project ${{ env.PROJECT }}
-
-      - name: Determine Variant
-        run: |
-          if [ "${{ env.VARIANT_INPUT }}" == "default" ] || [ -z "${{ env.VARIANT_INPUT }}" ]; then
-            echo "VARIANT=${{ env.BRANCH_TARGET }}" >> $GITHUB_ENV
-          else
-            echo "VARIANT=${{ env.VARIANT_INPUT }}" >> $GITHUB_ENV
-          fi
 
       - name: Checkout Kernel Source
         uses: actions/checkout@v6
@@ -140,7 +132,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.21
         with:
           variant: sccache
-          key: ${{ env.PROJECT }}-${{ env.VARIANT }}-${{ env.BRANCH_TARGET }}
+          key: kernel-build-shared-${{ env.PROJECT }}
           max-size: 5G
 
       - name: Install Dependencies
@@ -162,10 +154,42 @@ jobs:
             ARGS+=("--custom-build-time=${{ env.CUSTOM_BUILD_TIME }}")
           fi
           ./kokuban_ci_core build "${ARGS[@]}"
-      
+
+      - name: Collect Build Artifacts
+        if: always()
+        id: collect-artifacts
+        run: |
+          if ./kokuban_ci_core collect-artifacts --artifact-dir "$ARTIFACT_DIR"; then
+            :
+          else
+            echo "collect-artifacts command unavailable, falling back to shell collector."
+            mkdir -p "$ARTIFACT_DIR"
+            shopt -s nullglob
+
+            copied=0
+            for zipball in *.zip; do
+              cp "$zipball" "$ARTIFACT_DIR/"
+              copied=1
+            done
+
+            for extra_file in kernel_source/out/.config kernel_source/out/vmlinux.symvers; do
+              if [ -f "$extra_file" ]; then
+                cp "$extra_file" "$ARTIFACT_DIR/"
+                copied=1
+              fi
+            done
+
+            if [ "$copied" -eq 1 ]; then
+              echo "has_artifacts=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "has_artifacts=false" >> "$GITHUB_OUTPUT"
+              echo "No build artifacts were produced, skipping upload."
+            fi
+          fi
+
       - name: Upload Artifact
         uses: actions/upload-artifact@v7
-        if: always()
+        if: always() && steps.collect-artifacts.outputs.has_artifacts == 'true'
         with:
           name: ${{ env.PROJECT }}-kernel-${{ github.run_id }}
-          path: "*.zip"
+          path: ${{ env.ARTIFACT_DIR }}/*

--- a/.github/workflows/release_all.yml
+++ b/.github/workflows/release_all.yml
@@ -18,23 +18,17 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v6
-      
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@nightly
-        with:
-          toolchain: nightly
 
-      - name: Cache Rust
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: ci_core_rs
-
-      - name: Build CI Core
-        run: cargo build --release --locked --manifest-path ci_core_rs/Cargo.toml
+      - name: Download CI Core
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          gh release download ci-core-latest -p "kokuban_ci_core" --clobber
+          chmod +x kokuban_ci_core
           
       - name: Generate Matrix
         id: set-matrix
-        run: ./ci_core_rs/target/release/kokuban_ci_core matrix --project ${{ inputs.project }}
+        run: ./kokuban_ci_core matrix --project ${{ inputs.project }}
 
   build:
     needs: matrix

--- a/.github/workflows/release_all.yml
+++ b/.github/workflows/release_all.yml
@@ -30,7 +30,7 @@ jobs:
           workspaces: ci_core_rs
 
       - name: Build CI Core
-        run: cargo build --release --manifest-path ci_core_rs/Cargo.toml
+        run: cargo build --release --locked --manifest-path ci_core_rs/Cargo.toml
           
       - name: Generate Matrix
         id: set-matrix

--- a/.github/workflows/setup-kernel-repos.yml
+++ b/.github/workflows/setup-kernel-repos.yml
@@ -21,26 +21,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@nightly
-        with:
-          toolchain: nightly
 
-      - name: Cache Rust
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: ci_core_rs
-
-      - name: Build CI Core
-        run: cargo build --release --locked --manifest-path ci_core_rs/Cargo.toml
+      - name: Download CI Core
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          gh release download ci-core-latest -p "kokuban_ci_core" --clobber
+          chmod +x kokuban_ci_core
           
       - name: Initialize Repositories
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           WEBHOOK_SECRET: ${{ secrets.PUSH_SERVER_WEBHOOK_SECRET }}
         run: |
-          ./ci_core_rs/target/release/kokuban_ci_core setup \
+          ./kokuban_ci_core setup \
             --token "${{ secrets.GH_TOKEN }}" \
             --commit-message "${{ inputs.commit_message }}" \
             --readme-language "${{ inputs.readme_language }}"

--- a/.github/workflows/setup-kernel-repos.yml
+++ b/.github/workflows/setup-kernel-repos.yml
@@ -33,7 +33,7 @@ jobs:
           workspaces: ci_core_rs
 
       - name: Build CI Core
-        run: cargo build --release --manifest-path ci_core_rs/Cargo.toml
+        run: cargo build --release --locked --manifest-path ci_core_rs/Cargo.toml
           
       - name: Initialize Repositories
         env:

--- a/.github/workflows/update-kernelsu.yml
+++ b/.github/workflows/update-kernelsu.yml
@@ -6,7 +6,7 @@ on:
         description: 'Project to update'
         required: true
         type: choice
-        options: [z5_sm8550, s25_sm8750, s23_sm8550, s24_sm8650, tabs10_mt6989, mi17_sm8850]
+        options: [z5_sm8550, s25_sm8750, s23_sm8550, s24_sm8650, tabs10_mt6989, z6_sm8650, mi17_sm8850]
       branch:
         description: 'Variant (KernelSU Type)'
         required: true
@@ -37,15 +37,36 @@ jobs:
           workspaces: ci_core_rs
 
       - name: Build CI Core
-        run: cargo build --release --manifest-path ci_core_rs/Cargo.toml
-          
+        run: cargo build --release --locked --manifest-path ci_core_rs/Cargo.toml
+
       - name: Determine Commit Hash
         id: hash
         run: |
+          set -euo pipefail
+
           if [ "${{ inputs.commit_id }}" == "latest" ]; then
-             echo "COMMIT_ID=$(git ls-remote https://github.com/tiann/KernelSU.git main | cut -c1-7)" >> $GITHUB_ENV
+            case "${{ inputs.branch }}" in
+              ksu)
+                repo="https://github.com/tiann/KernelSU.git"
+                branch="main"
+                ;;
+              mksu)
+                repo="https://github.com/5ec1cff/KernelSU.git"
+                branch="main"
+                ;;
+              resukisu)
+                repo="https://github.com/ReSukiSU/ReSukiSU.git"
+                branch="main"
+                ;;
+              *)
+                echo "Unsupported KernelSU variant: ${{ inputs.branch }}"
+                exit 1
+                ;;
+            esac
+
+            echo "COMMIT_ID=$(git ls-remote \"$repo\" \"$branch\" | cut -c1-7)" >> "$GITHUB_ENV"
           else
-             echo "COMMIT_ID=${{ inputs.commit_id }}" >> $GITHUB_ENV
+            echo "COMMIT_ID=${{ inputs.commit_id }}" >> "$GITHUB_ENV"
           fi
 
       - name: Execute Update

--- a/.github/workflows/update-kernelsu.yml
+++ b/.github/workflows/update-kernelsu.yml
@@ -25,19 +25,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@nightly
-        with:
-          toolchain: nightly
 
-      - name: Cache Rust
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: ci_core_rs
-
-      - name: Build CI Core
-        run: cargo build --release --locked --manifest-path ci_core_rs/Cargo.toml
+      - name: Download CI Core
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          gh release download ci-core-latest -p "kokuban_ci_core" --clobber
+          chmod +x kokuban_ci_core
 
       - name: Determine Commit Hash
         id: hash
@@ -71,7 +65,7 @@ jobs:
 
       - name: Execute Update
         run: |
-          ./ci_core_rs/target/release/kokuban_ci_core update \
+          ./kokuban_ci_core update \
             --token "${{ secrets.GH_TOKEN }}" \
             --project "${{ inputs.project }}" \
             --variant "${{ inputs.branch }}" \

--- a/.github/workflows/upstream-watcher.yml
+++ b/.github/workflows/upstream-watcher.yml
@@ -15,23 +15,17 @@ jobs:
       found_updates: ${{ steps.watcher.outputs.found_updates }}
     steps:
       - uses: actions/checkout@v6
-      
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@nightly
-        with:
-          toolchain: nightly
 
-      - name: Cache Rust
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: ci_core_rs
-
-      - name: Build CI Core
-        run: cargo build --release --locked --manifest-path ci_core_rs/Cargo.toml
+      - name: Download CI Core
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          gh release download ci-core-latest -p "kokuban_ci_core" --clobber
+          chmod +x kokuban_ci_core
           
       - name: Check Upstream
         id: watcher
-        run: ./ci_core_rs/target/release/kokuban_ci_core watch
+        run: ./kokuban_ci_core watch
         
       - name: Commit Updated Tracker
         if: steps.watcher.outputs.found_updates == 'true'
@@ -52,23 +46,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@nightly
-        with:
-          toolchain: nightly
 
-      - name: Cache Rust
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: ci_core_rs
-
-      - name: Build CI Core
-        run: cargo build --release --locked --manifest-path ci_core_rs/Cargo.toml
+      - name: Download CI Core
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          gh release download ci-core-latest -p "kokuban_ci_core" --clobber
+          chmod +x kokuban_ci_core
           
       - name: Perform Update
         run: |
-          ./ci_core_rs/target/release/kokuban_ci_core update \
+          ./kokuban_ci_core update \
             --token "${{ secrets.GH_TOKEN }}" \
             --project "${{ matrix.project }}" \
             --variant "${{ matrix.variant }}" \

--- a/.github/workflows/upstream-watcher.yml
+++ b/.github/workflows/upstream-watcher.yml
@@ -27,7 +27,7 @@ jobs:
           workspaces: ci_core_rs
 
       - name: Build CI Core
-        run: cargo build --release --manifest-path ci_core_rs/Cargo.toml
+        run: cargo build --release --locked --manifest-path ci_core_rs/Cargo.toml
           
       - name: Check Upstream
         id: watcher
@@ -64,7 +64,7 @@ jobs:
           workspaces: ci_core_rs
 
       - name: Build CI Core
-        run: cargo build --release --manifest-path ci_core_rs/Cargo.toml
+        run: cargo build --release --locked --manifest-path ci_core_rs/Cargo.toml
           
       - name: Perform Update
         run: |

--- a/ci_core_rs/src/build.rs
+++ b/ci_core_rs/src/build.rs
@@ -7,7 +7,41 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 
 use crate::config::ProjectConfig;
-use crate::utils::{handle_notify, load_projects, run_cmd, run_cmd_with_env};
+use crate::utils::{handle_notify, load_projects, run_cmd, run_cmd_with_env, set_github_output};
+
+fn command_exists(command: &str) -> bool {
+    std::process::Command::new(command)
+        .arg("-V")
+        .output()
+        .is_ok()
+}
+
+fn create_compiler_wrapper(
+    wrapper_dir: &Path,
+    wrapper_name: &str,
+    command_prefix: &str,
+    tool: &str,
+) -> Result<String> {
+    let wrapper_path = wrapper_dir.join(wrapper_name);
+    fs::write(
+        &wrapper_path,
+        format!("#!/bin/sh\nexec {} {} \"$@\"\n", command_prefix, tool),
+    )?;
+    fs::set_permissions(&wrapper_path, PermissionsExt::from_mode(0o755))?;
+    Ok(wrapper_path.to_string_lossy().to_string())
+}
+
+fn copy_artifact_if_exists(source: &Path, artifact_dir: &Path) -> Result<bool> {
+    if !source.is_file() {
+        return Ok(false);
+    }
+
+    let file_name = source
+        .file_name()
+        .ok_or_else(|| anyhow!("Artifact path {:?} has no filename", source))?;
+    fs::copy(source, artifact_dir.join(file_name))?;
+    Ok(true)
+}
 
 pub fn handle_build(
     project_key: String,
@@ -32,37 +66,16 @@ pub fn handle_build(
     let wrapper_dir = env::current_dir()?.join(".compiler_wrappers");
     let _ = fs::create_dir_all(&wrapper_dir);
 
-    let rust_cmd = if std::process::Command::new("sccache")
-        .arg("-V")
-        .output()
-        .is_ok()
-    {
-        let wrapper_path = wrapper_dir.join("rustc");
-        fs::write(&wrapper_path, "#!/bin/sh\nexec sccache rustc \"$@\"\n")?;
-        fs::set_permissions(&wrapper_path, PermissionsExt::from_mode(0o755))?;
-        wrapper_path.to_string_lossy().to_string()
+    let rust_cmd = if command_exists("sccache") {
+        create_compiler_wrapper(&wrapper_dir, "rustc", "sccache", "rustc")?
     } else {
         "rustc".to_string()
     };
 
-    let cc_cmd = if std::process::Command::new("sccache")
-        .arg("-V")
-        .output()
-        .is_ok()
-    {
-        let wrapper_path = wrapper_dir.join("clang");
-        fs::write(&wrapper_path, "#!/bin/sh\nexec sccache clang \"$@\"\n")?;
-        fs::set_permissions(&wrapper_path, PermissionsExt::from_mode(0o755))?;
-        wrapper_path.to_string_lossy().to_string()
-    } else if std::process::Command::new("ccache")
-        .arg("-V")
-        .output()
-        .is_ok()
-    {
-        let wrapper_path = wrapper_dir.join("clang");
-        fs::write(&wrapper_path, "#!/bin/sh\nexec ccache clang \"$@\"\n")?;
-        fs::set_permissions(&wrapper_path, PermissionsExt::from_mode(0o755))?;
-        wrapper_path.to_string_lossy().to_string()
+    let cc_cmd = if command_exists("sccache") {
+        create_compiler_wrapper(&wrapper_dir, "clang", "sccache", "clang")?
+    } else if command_exists("ccache") {
+        create_compiler_wrapper(&wrapper_dir, "clang", "ccache", "clang")?
     } else {
         "clang".to_string()
     };
@@ -656,6 +669,41 @@ pub fn handle_build(
         } else {
             return Err(anyhow!("Final zip not found"));
         }
+    }
+
+    Ok(())
+}
+
+pub fn handle_collect_artifacts(artifact_dir: String) -> Result<()> {
+    let artifact_dir = PathBuf::from(artifact_dir);
+    fs::create_dir_all(&artifact_dir)?;
+
+    let mut has_artifacts = false;
+
+    for entry in fs::read_dir(".")? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(|ext| ext.to_str()) == Some("zip") {
+            has_artifacts |= copy_artifact_if_exists(&path, &artifact_dir)?;
+        }
+    }
+
+    for extra_artifact in [
+        "kernel_source/out/.config",
+        "kernel_source/out/vmlinux.symvers",
+    ] {
+        has_artifacts |= copy_artifact_if_exists(Path::new(extra_artifact), &artifact_dir)?;
+    }
+
+    set_github_output(
+        "has_artifacts",
+        if has_artifacts { "true" } else { "false" },
+    )?;
+
+    if has_artifacts {
+        println!("Collected build artifacts into {}", artifact_dir.display());
+    } else {
+        println!("No build artifacts were produced, skipping upload.");
     }
 
     Ok(())

--- a/ci_core_rs/src/main.rs
+++ b/ci_core_rs/src/main.rs
@@ -100,6 +100,10 @@ enum Commands {
         #[arg(long, allow_hyphen_values = true)]
         custom_build_time: Option<String>,
     },
+    CollectArtifacts {
+        #[arg(long, default_value = "build_artifacts")]
+        artifact_dir: String,
+    },
 }
 
 fn main() -> Result<()> {
@@ -158,6 +162,9 @@ fn main() -> Result<()> {
             custom_localversion,
             custom_build_time,
         ),
+        Commands::CollectArtifacts { artifact_dir } => {
+            build::handle_collect_artifacts(artifact_dir)
+        }
     }
 }
 

--- a/ci_core_rs/src/utils.rs
+++ b/ci_core_rs/src/utils.rs
@@ -45,12 +45,20 @@ pub fn save_json<T: serde::Serialize>(path: &Path, data: &T) -> Result<()> {
     Ok(())
 }
 
-pub fn set_github_env(key: &str, value: &str) -> Result<()> {
-    if let Ok(path) = env::var("GITHUB_ENV") {
+fn write_github_kv(var_name: &str, key: &str, value: &str) -> Result<()> {
+    if let Ok(path) = env::var(var_name) {
         let mut file = OpenOptions::new().append(true).create(true).open(path)?;
         writeln!(file, "{}={}", key, value)?;
     }
     Ok(())
+}
+
+pub fn set_github_env(key: &str, value: &str) -> Result<()> {
+    write_github_kv("GITHUB_ENV", key, value)
+}
+
+pub fn set_github_output(key: &str, value: &str) -> Result<()> {
+    write_github_kv("GITHUB_OUTPUT", key, value)
 }
 
 pub fn run_cmd(cmd: &[&str], cwd: Option<&Path>, capture: bool) -> Result<Option<String>> {


### PR DESCRIPTION
### Motivation
- Improve reliability of CI builds by using locked Cargo builds and more robust input resolution for workflow triggers.
- Ensure build artifacts are consistently collected and uploaded even when the primary collector is unavailable.
- Use local compiler wrapper scripts to transparently enable `sccache`/`ccache` for both Rust and C toolchains.
- Add better KernelSU update handling and expand supported project variants.

### Description
- Updated GitHub workflows to run `cargo build --release --locked` and added an `ARTIFACT_DIR` environment variable, enhanced input resolution to support `repository_dispatch` and `workflow_call`, changed sccache cache key to a shared key, and added a fallback artifact collection step with conditional upload.
- Added a new CLI subcommand `CollectArtifacts` and Rust function `handle_collect_artifacts` that copy `.zip` artifacts and extra files into the configured artifact directory and emit a `has_artifacts` GitHub output via `GITHUB_OUTPUT`.
- Introduced helper functions in `ci_core_rs/src/build.rs` (`command_exists`, `create_compiler_wrapper`, `copy_artifact_if_exists`) to create executable compiler wrappers and use them to set `RUSTC`/`CC`/`HOST*` variables when `sccache` or `ccache` are present.
- Refactored GitHub env/output writers in `ci_core_rs/src/utils.rs` into `write_github_kv` and exported `set_github_env` and new `set_github_output` helpers used by the artifact collector.
- Improved `update-kernelsu.yml` to include `z6_sm8650` and added logic to resolve correct KernelSU repo and branch per variant.

### Testing
- No automated tests were executed as part of this change; CI workflows were updated to perform the locked builds and artifact collection steps when run by GitHub Actions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bace8254388325811148810dcfd9a0)