### PR TITLE
Download release assets into temp dir and include hidden files in artifact upload

### DIFF
--- a/.github/workflows/build_kernel.yml
+++ b/.github/workflows/build_kernel.yml
@@ -193,3 +193,4 @@ jobs:
         with:
           name: ${{ env.PROJECT }}-kernel-${{ github.run_id }}
           path: ${{ env.ARTIFACT_DIR }}
+          include-hidden-files: true

--- a/ci_core_rs/src/utils.rs
+++ b/ci_core_rs/src/utils.rs
@@ -222,6 +222,12 @@ pub fn handle_notify(tag_name: String) -> Result<()> {
     );
 
     let client = reqwest::blocking::Client::new();
+    let temp_download_dir = env::temp_dir().join(format!(
+        "kokuban_notify_{}_{}",
+        std::process::id(),
+        tag_name.replace(['/', '\\', ' '], "_")
+    ));
+    fs::create_dir_all(&temp_download_dir)?;
 
     for (chat_id, topic_id) in &destinations {
         let mut json_body = HashMap::new();
@@ -263,9 +269,11 @@ pub fn handle_notify(tag_name: String) -> Result<()> {
                     name,
                     "--clobber",
                 ],
-                None,
+                Some(&temp_download_dir),
                 false,
             )?;
+
+            let asset_path = temp_download_dir.join(name);
 
             for (chat_id, topic_id) in &destinations {
                 let caption = format!(
@@ -284,7 +292,7 @@ pub fn handle_notify(tag_name: String) -> Result<()> {
                     form
                 };
 
-                let file_content = fs::read(name)?;
+                let file_content = fs::read(&asset_path)?;
                 let part = reqwest::blocking::multipart::Part::bytes(file_content)
                     .file_name(name.to_owned());
                 let form = form.part("document", part);
@@ -297,10 +305,14 @@ pub fn handle_notify(tag_name: String) -> Result<()> {
                     .multipart(form)
                     .send();
             }
-            if Path::new(name).exists() {
-                fs::remove_file(name)?;
+            if asset_path.exists() {
+                fs::remove_file(&asset_path)?;
             }
         }
+    }
+
+    if temp_download_dir.exists() {
+        fs::remove_dir_all(temp_download_dir)?;
     }
 
     Ok(())


### PR DESCRIPTION
### Motivation

- Prevent collisions and working-directory pollution when downloading GitHub release assets and ensure uploaded artifacts include hidden files.

### Description

- Create a per-run temporary download directory using `env::temp_dir()` and the process id plus a sanitized `tag_name`, and `create_dir_all` it before downloads. 
- Pass the temp directory to `run_cmd` so `gh release download` writes assets into the temp location and use `temp_download_dir.join(name)` when reading and removing asset files. 
- Remove each downloaded asset after sending and delete the temporary download directory at the end of `handle_notify`. 
- Update `.github/workflows/build_kernel.yml` to set `include-hidden-files: true` on the `actions/upload-artifact@v7` step.

### Testing

- Ran `cargo build` and `cargo test` for the modified Rust crate and all tests completed successfully. 
- Linted and validated the modified GitHub Actions workflow and the artifact upload step accepts the new `include-hidden-files` option without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc1c90388883258cb680e3367aabf4)