### PR TITLE
fix: use gki_defconfig for mi17_sm8850

### DIFF
--- a/configs/projects.json
+++ b/configs/projects.json
@@ -241,7 +241,7 @@
   },
   "mi17_sm8850": {
     "repo": "YuzakiKokuban/android_kernel_xiaomi_sm8850",
-    "defconfig": "defconfig",
+    "defconfig": "gki_defconfig",
     "localversion_base": "-android16-Kokuban-SilverWolf",
     "supported_ksu": [
       "resukisu",


### PR DESCRIPTION
### Motivation
- The central CI config used `defconfig` for `mi17_sm8850` while the community build scripts and known-good GKI flow use `gki_defconfig`, causing mismatched configuration and unreproducible / unusable Xiaomi 17 builds.

### Description
- Update `configs/projects.json` to change `mi17_sm8850.defconfig` from `defconfig` to `gki_defconfig`, keeping existing toolchain and packaging settings unchanged so the central CI aligns with the community GKI build flow.

### Testing
- Verified the change with a small assertion (`python` script confirming `mi17_sm8850.defconfig == "gki_defconfig"`) and file inspection, and noted that `kernel_source` is absent in the repo so a full kernel build could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd1f6c18488325973e58fa036c1e82)