### PR TITLE
Write Mi17 (sm8850) localversion into out/.config (CONFIG_LOCALVERSION)

### DIFF
--- a/ci_core_rs/src/build.rs
+++ b/ci_core_rs/src/build.rs
@@ -548,10 +548,17 @@ pub fn handle_build(
         make_args.push("LOCALVERSION_AUTO=n");
         build_env.insert("LOCALVERSION_AUTO".to_string(), "n".to_string());
 
-        let setlocalversion_path = kernel_source_path.join("scripts/setlocalversion");
-        if setlocalversion_path.exists() {
-            let script_content = format!("#!/bin/sh\necho \"{}\"\n", localversion);
-            let _ = fs::write(&setlocalversion_path, script_content);
+        let out_config_path = kernel_source_path.join("out/.config");
+        if out_config_path.exists() {
+            let config_content = fs::read_to_string(&out_config_path).unwrap_or_default();
+            let config_content = upsert_kconfig_entry(
+                &config_content,
+                "CONFIG_LOCALVERSION",
+                &format!("\"{}\"", localversion),
+            );
+            let config_content =
+                upsert_kconfig_entry(&config_content, "CONFIG_LOCALVERSION_AUTO", "n");
+            let _ = fs::write(&out_config_path, config_content);
         }
     }
 


### PR DESCRIPTION
### Motivation
- Make Xiaomi 17 (`sm8850`) kernel builds set the localversion by writing `CONFIG_LOCALVERSION` into the generated `.config` instead of altering `scripts/setlocalversion`, so the `.config` directly reflects the desired localversion.

### Description
- Update `ci_core_rs/src/build.rs` to, for `sm8850`, read `out/.config` and `upsert_kconfig_entry` to set `CONFIG_LOCALVERSION` to the generated value and `CONFIG_LOCALVERSION_AUTO` to `n` before writing the file back.
- Preserve the existing localversion value generation logic, including the fallback `localversion_base + -g<short_sha>-4k` when `custom_localversion` is not provided.
- Continue forcing `LOCALVERSION_AUTO=n` in the build environment as before and keep non-`sm8850` behavior unchanged.
- Remove the previous behavior that wrote a small `scripts/setlocalversion` echo script for `sm8850` builds.

### Testing
- Ran `cargo fmt --manifest-path ci_core_rs/Cargo.toml` and it succeeded.
- Ran `cargo check --manifest-path ci_core_rs/Cargo.toml` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be00644c3483258c71fc41b8c182c0)