### PR TITLE
fix: align mi17 localversion handling with community script

### DIFF
--- a/ci_core_rs/src/build.rs
+++ b/ci_core_rs/src/build.rs
@@ -70,6 +70,56 @@ fn upsert_kconfig_entry(content: &str, key: &str, value: &str) -> String {
     lines.join("\n") + "\n"
 }
 
+fn apply_sm8850_localversion(
+    kernel_source_path: &Path,
+    defconfig_name: &str,
+    localversion: &str,
+) -> Result<()> {
+    let setlocalversion_path = kernel_source_path.join("scripts/setlocalversion");
+    if setlocalversion_path.exists() {
+        let mut content = fs::read_to_string(&setlocalversion_path).unwrap_or_default();
+        content = content.replace(" -dirty", "");
+
+        let dirty_cleanup_line = r#"res=$(echo "$res" | sed 's/-dirty//g')"#;
+        if !content.contains(dirty_cleanup_line) {
+            if let Some(last_echo_pos) = content.rfind(r#"echo "$res""#) {
+                content.insert_str(last_echo_pos, &format!("{dirty_cleanup_line}\n"));
+            } else {
+                if !content.ends_with('\n') {
+                    content.push('\n');
+                }
+                content.push_str(dirty_cleanup_line);
+                content.push('\n');
+            }
+        }
+
+        if let Some(last_echo_pos) = content.rfind(r#"echo "$res""#) {
+            content.replace_range(
+                last_echo_pos..last_echo_pos + r#"echo "$res""#.len(),
+                &format!(r#"echo "{}""#, localversion),
+            );
+        }
+
+        content = content.replace("${scm_version}", "");
+        fs::write(&setlocalversion_path, content)?;
+    }
+
+    let defconfig_path = kernel_source_path.join(format!("arch/arm64/configs/{}", defconfig_name));
+    if defconfig_path.exists() {
+        let mut defconfig_content = fs::read_to_string(&defconfig_path).unwrap_or_default();
+        defconfig_content = upsert_kconfig_entry(
+            &defconfig_content,
+            "CONFIG_LOCALVERSION",
+            &format!("\"{}\"", localversion),
+        );
+        defconfig_content =
+            upsert_kconfig_entry(&defconfig_content, "CONFIG_LOCALVERSION_AUTO", "n");
+        fs::write(defconfig_path, defconfig_content)?;
+    }
+
+    Ok(())
+}
+
 pub fn handle_build(
     project_key: String,
     branch: String,
@@ -294,17 +344,6 @@ pub fn handle_build(
         run_cmd(&["bash", "-c", &cmd], Some(&kernel_source_path), false)?;
     }
 
-    if target_soc_str == "sm8850" {
-        let setlocalversion_path = kernel_source_path.join("scripts/setlocalversion");
-        if setlocalversion_path.exists() {
-            let content = fs::read_to_string(&setlocalversion_path).unwrap_or_default();
-            let new_content = content
-                .replace(" -dirty", "")
-                .replace("res=\"$res+\"", "res=\"$res\"");
-            let _ = fs::write(&setlocalversion_path, new_content);
-        }
-    }
-
     let kernel_version_cmd = if target_soc_str == "sm8850" {
         vec![
             "bash",
@@ -319,6 +358,15 @@ pub fn handle_build(
         .unwrap_or_else(|| "unknown".to_string())
         .trim()
         .to_string();
+
+    let short_sha = run_cmd(
+        &["git", "rev-parse", "--short=12", "HEAD"],
+        Some(&kernel_source_path),
+        true,
+    )?
+    .unwrap_or_else(|| "unknown".to_string())
+    .trim()
+    .to_string();
 
     let mut make_args = vec![
         "O=out",
@@ -358,6 +406,35 @@ pub fn handle_build(
     build_env.insert("HOSTCC".to_string(), cc_cmd.clone());
     build_env.insert("LD".to_string(), "ld.lld".to_string());
     build_env.insert("HOSTLD".to_string(), "ld.lld".to_string());
+
+    let variant_suffix = match branch.as_str() {
+        "main" | "lkm" => "LKM".to_string(),
+        "ksu" => "KSU".to_string(),
+        "mksu" => "MKSU".to_string(),
+        "resukisu" | "sukisuultra" => "ReSuki".to_string(),
+        _ => branch.to_uppercase(),
+    };
+
+    let mut localversion = if let Some(ref custom) = custom_localversion {
+        let custom = custom.trim();
+        if target_soc_str == "sm8850" {
+            format!("-{}", custom.trim_start_matches('-'))
+        } else {
+            custom.to_string()
+        }
+    } else {
+        format!("{}-{}", proj.localversion_base, variant_suffix)
+    };
+
+    if target_soc_str == "sm8850" {
+        if custom_localversion.is_none() {
+            localversion = format!("{}-g{}-4k", proj.localversion_base, short_sha);
+        }
+        let _ = fs::write(kernel_source_path.join(".scmversion"), "");
+        make_args.push("LOCALVERSION_AUTO=n");
+        build_env.insert("LOCALVERSION_AUTO".to_string(), "n".to_string());
+        apply_sm8850_localversion(&kernel_source_path, &proj.defconfig, &localversion)?;
+    }
 
     if target_soc_str == "sm8850" {
         let build_config_path = kernel_source_path.join("build.config.gki");
@@ -514,52 +591,10 @@ pub fn handle_build(
         run_cmd_with_env(&olddefconfig_cmd, Some(&kernel_source_path), &build_env)?;
     }
 
-    let short_sha = run_cmd(
-        &["git", "rev-parse", "--short=12", "HEAD"],
-        Some(&kernel_source_path),
-        true,
-    )?
-    .unwrap_or_else(|| "unknown".to_string())
-    .trim()
-    .to_string();
-
-    let variant_suffix = match branch.as_str() {
-        "main" | "lkm" => "LKM".to_string(),
-        "ksu" => "KSU".to_string(),
-        "mksu" => "MKSU".to_string(),
-        "resukisu" | "sukisuultra" => "ReSuki".to_string(),
-        _ => branch.to_uppercase(),
-    };
-
-    let mut localversion = if let Some(ref custom) = custom_localversion {
+    if custom_localversion.is_some() && target_soc_str != "sm8850" {
         let _ = fs::write(kernel_source_path.join(".scmversion"), "");
         make_args.push("LOCALVERSION_AUTO=n");
         build_env.insert("LOCALVERSION_AUTO".to_string(), "n".to_string());
-        custom.clone()
-    } else {
-        format!("{}-{}", proj.localversion_base, variant_suffix)
-    };
-
-    if target_soc_str == "sm8850" {
-        if custom_localversion.is_none() {
-            localversion = format!("{}-g{}-4k", proj.localversion_base, short_sha);
-        }
-        let _ = fs::write(kernel_source_path.join(".scmversion"), "");
-        make_args.push("LOCALVERSION_AUTO=n");
-        build_env.insert("LOCALVERSION_AUTO".to_string(), "n".to_string());
-
-        let out_config_path = kernel_source_path.join("out/.config");
-        if out_config_path.exists() {
-            let config_content = fs::read_to_string(&out_config_path).unwrap_or_default();
-            let config_content = upsert_kconfig_entry(
-                &config_content,
-                "CONFIG_LOCALVERSION",
-                &format!("\"{}\"", localversion),
-            );
-            let config_content =
-                upsert_kconfig_entry(&config_content, "CONFIG_LOCALVERSION_AUTO", "n");
-            let _ = fs::write(&out_config_path, config_content);
-        }
     }
 
     let localversion_arg = format!("LOCALVERSION={}", localversion);


### PR DESCRIPTION
### Motivation
- Ensure Xiaomi 17 (`sm8850`) builds produce the same `localversion` behavior as the community scripts by applying the same `scripts/setlocalversion` and `gki_defconfig` edits. 
- Make those edits take effect before defconfig generation so the modified `setlocalversion`/defconfig state is used throughout the normal build flow.

### Description
- Add a helper `apply_sm8850_localversion` in `ci_core_rs/src/build.rs` that edits `scripts/setlocalversion` to remove ` -dirty`, insert `res=$(echo "$res" | sed 's/-dirty//g')`, replace the final `echo "$res"` with the target `localversion`, and strip `${scm_version}`. 
- Have the helper also update the Xiaomi `gki_defconfig` (`arch/arm64/configs/<defconfig>`) to set `CONFIG_LOCALVERSION` and `CONFIG_LOCALVERSION_AUTO=n` when present. 
- Move Xiaomi `localversion` computation earlier in the build flow and generate the `sm8850`-specific suffix (`-g<short_sha>-4k`) when no custom suffix is passed, matching the community script logic. 
- Normalize custom suffix input for `sm8850` to the single leading-hyphen format expected by the community script and keep other projects' `localversion` handling unchanged while preserving `LOCALVERSION_AUTO` / `LOCALVERSION` behavior per `version_method`.

### Testing
- Ran `cargo fmt --manifest-path ci_core_rs/Cargo.toml` which completed successfully. 
- Ran `cargo check --manifest-path ci_core_rs/Cargo.toml` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be07f14eec8325b8f6b81d76d77494)