### PR TITLE
Don't override final release echo in apply_sm8850_localversion

### DIFF
--- a/ci_core_rs/src/build.rs
+++ b/ci_core_rs/src/build.rs
@@ -95,13 +95,6 @@ fn apply_sm8850_localversion(
             }
         }
 
-        if let Some(final_echo_pos) = content.rfind(final_release_echo) {
-            content.replace_range(
-                final_echo_pos..final_echo_pos + final_release_echo.len(),
-                &format!(r#"echo "{}""#, localversion),
-            );
-        }
-
         content = content.replace("${scm_version}", "");
         fs::write(&setlocalversion_path, content)?;
     }


### PR DESCRIPTION
### Motivation
- Prevent forcing a fixed `echo` with the custom localversion in `apply_sm8850_localversion` so the kernel's composed version remains intact while still cleaning `-dirty` and removing `${scm_version}`.

### Description
- Remove the code that replaced the `final_release_echo` with a hardcoded `echo "<localversion>"`, while keeping the insertion of the dirty-cleanup line and the replacement of `${scm_version}` and the updates to `CONFIG_LOCALVERSION` and `CONFIG_LOCALVERSION_AUTO`.

### Testing
- Built the crate with `cargo build` and ran `cargo test` for `ci_core_rs`, and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be1ae669e48325959ba50d653604b0)