### PR TITLE
Fix release artifact name collisions

### DIFF
--- a/.github/workflows/build_kernel.yml
+++ b/.github/workflows/build_kernel.yml
@@ -99,6 +99,9 @@ jobs:
             resolved_variant="$variant"
           fi
 
+          safe_artifact_branch=$(printf '%s' "$branch" | sed 's#[^A-Za-z0-9._-]#-#g')
+          artifact_name="${project}-kernel-${safe_artifact_branch}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
           {
             echo "PROJECT=$project"
             echo "BRANCH_TARGET=$branch"
@@ -107,6 +110,7 @@ jobs:
             echo "DO_RELEASE=$release"
             echo "CUSTOM_LOCALVERSION=$custom_localversion"
             echo "CUSTOM_BUILD_TIME=$custom_build_time"
+            echo "ARTIFACT_NAME=$artifact_name"
           } >> "$GITHUB_ENV"
 
       - name: Download CI Core
@@ -191,6 +195,6 @@ jobs:
         uses: actions/upload-artifact@v7
         if: always() && steps.collect-artifacts.outputs.has_artifacts == 'true'
         with:
-          name: ${{ env.PROJECT }}-kernel-${{ github.run_id }}
+          name: ${{ env.ARTIFACT_NAME }}
           path: ${{ env.ARTIFACT_DIR }}
           include-hidden-files: true


### PR DESCRIPTION
### Motivation
- Matrix builds triggered by the "Release All Branches" workflow were uploading artifacts with the same name and causing `409 Conflict` errors because the previous artifact name only used the workflow run id and was identical across branch matrix entries.

### Description
- Compute a sanitized branch token with `safe_artifact_branch=$(printf '%s' "$branch" | sed 's#[^A-Za-z0-9._-]#-#g')` and assemble `artifact_name` using the project, sanitized branch, `GITHUB_RUN_ID`, and `GITHUB_RUN_ATTEMPT`.
- Export the computed `ARTIFACT_NAME` to `GITHUB_ENV` in the reusable build workflow parameter resolution block.
- Update the `actions/upload-artifact@v7` step to use `name: ${{ env.ARTIFACT_NAME }}` so each matrix job uploads a unique artifact name.
- The change was applied to `.github/workflows/build_kernel.yml`.

### Testing
- Validated the new artifact naming strings are present using a Python assertion script that checked for the sanitized branch computation, `artifact_name` assignment, and `name: ${{ env.ARTIFACT_NAME }}` in the workflow file, and the checks passed.
- Inspected the workflow snippet lines to confirm the `ARTIFACT_NAME` is written to `GITHUB_ENV` and referenced in the upload step, and the inspection showed the expected lines.
- No runtime workflow executions were performed as part of this change, only static validation of the workflow file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be3389b478832580f8d9c2152e650c)