### PR TITLE
ci: track ReSukiSU dev branch

### DIFF
--- a/.github/workflows/reusable-update-kernel-source.yml
+++ b/.github/workflows/reusable-update-kernel-source.yml
@@ -47,7 +47,7 @@ jobs:
             echo "Unsupported ksu_type: $KSU_TYPE"
             exit 1
           fi
-          SETUP_URL="https://raw.githubusercontent.com/ReSukiSU/ReSukiSU/main/kernel/setup.sh"
+          SETUP_URL="https://raw.githubusercontent.com/ReSukiSU/ReSukiSU/dev/kernel/setup.sh"
 
           echo "Updating projects with commit message: '$COMMIT_MESSAGE'"
           
@@ -68,7 +68,7 @@ jobs:
             cp ${{ github.workspace }}/configs/universal.gitignore ./.gitignore
 
             echo "Running setup.sh from $SETUP_URL..."
-            curl -LSs "$SETUP_URL" | bash -s main
+            curl -LSs "$SETUP_URL" | bash -s dev
             
             git config --global user.name "GitHub Actions"
             git config --global user.email "actions@github.com"

--- a/.github/workflows/update-kernelsu.yml
+++ b/.github/workflows/update-kernelsu.yml
@@ -40,7 +40,7 @@ jobs:
 
           if [ "${{ inputs.commit_id }}" == "latest" ]; then
             repo="https://github.com/ReSukiSU/ReSukiSU.git"
-            branch="main"
+            branch="dev"
             echo "COMMIT_ID=$(git ls-remote \"$repo\" \"$branch\" | cut -c1-7)" >> "$GITHUB_ENV"
           else
             echo "COMMIT_ID=${{ inputs.commit_id }}" >> "$GITHUB_ENV"

--- a/ci_core_rs/src/build.rs
+++ b/ci_core_rs/src/build.rs
@@ -1177,11 +1177,11 @@ pub fn handle_build(
         .as_deref()
         .map(str::trim)
         .filter(|arg| !arg.is_empty())
-        .unwrap_or("main");
+        .unwrap_or("dev");
 
     let setup_url = match branch.as_str() {
         _ if is_resukisu_variant(&branch) => Some((
-            "https://raw.githubusercontent.com/ReSukiSU/ReSukiSU/main/kernel/setup.sh",
+            "https://raw.githubusercontent.com/ReSukiSU/ReSukiSU/dev/kernel/setup.sh",
             resukisu_setup_arg,
         )),
         _ => None,

--- a/ci_core_rs/src/config.rs
+++ b/ci_core_rs/src/config.rs
@@ -70,9 +70,9 @@ pub struct AnyKernelConfig {
 pub const KSU_CONFIG_JSON: &str = r#"{
     "resukisu": {
         "repo": "https://github.com/ReSukiSU/ReSukiSU.git",
-        "branch": "main",
-        "setup_url": "https://raw.githubusercontent.com/ReSukiSU/ReSukiSU/main/kernel/setup.sh",
-        "setup_args": ["main"]
+        "branch": "dev",
+        "setup_url": "https://raw.githubusercontent.com/ReSukiSU/ReSukiSU/dev/kernel/setup.sh",
+        "setup_args": ["dev"]
     }
 }"#;
 

--- a/configs/upstream_commits.json
+++ b/configs/upstream_commits.json
@@ -1,3 +1,3 @@
 {
-  "resukisu": "b09af429463dedb8a7639268945ad8172892d25c"
+  "resukisu": "bf046222eec9c7f41d5f10ac4aafa674ec90acbf"
 }


### PR DESCRIPTION
### Motivation

- Switch ReSukiSU upstream listening and build-time setup from the `main` branch to `dev` so the watcher and build flows follow the `dev` workstream.

### Description

- Update the KSU upstream configuration in `ci_core_rs/src/config.rs` so `KSU_CONFIG_JSON` uses `"branch": "dev"`, the `dev` `setup_url`, and `setup_args` set to `dev`.
- Change build defaults in `ci_core_rs/src/build.rs` to use `dev` as the fallback `resukisu_setup_arg` and to call the `dev` `setup.sh` URL when building `resukisu` variants.
- Update workflows `.github/workflows/update-kernelsu.yml` and `.github/workflows/reusable-update-kernel-source.yml` to target the `dev` branch and invoke `setup.sh` with `bash -s dev`.
- Refresh `configs/upstream_commits.json` to the current `dev` HEAD hash for `resukisu`.

### Testing

- Ran `cargo fmt --check` which passed without issues.
- Ran `cargo test` and all unit tests passed (`7 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a046a86ae908325bec9fb9d99dafe61)